### PR TITLE
Various API improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Formats a standard error and its sources"
 repository = "https://github.com/mexus/display-error-chain.git"
 documentation = "https://docs.rs/display-error-chain"
 license = "Apache-2.0/MIT"
-keywords = [ "error", "format-error" ]
+keywords = ["error", "format-error"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "display-error-chain"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["mexus <null@mexus.xyz>"]
 edition = "2021"
 description = "Formats a standard error and its sources"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # display-error-chain
 
+<!-- cargo-rdme start -->
+
 A lightweight library for displaying errors and their sources.
 
 A sample output:
@@ -7,7 +9,6 @@ A sample output:
 ```rust
 macro_rules! impl_error {
     // ...
-#
 }
 
 // `TopLevel` is caused by a `MidLevel`.
@@ -35,6 +36,32 @@ Caused by:
   -> mid level
   -> low level"
 );
+
+// Or with `.chain()` helper:
+use display_error_chain::ErrorChainExt as _;
+let formatted = TopLevel.chain().to_string();
+assert_eq!(
+    formatted,
+    "\
+top level
+Caused by:
+  -> mid level
+  -> low level"
+);
+
+// Or even with `.into_chain()` helper to consume the error.
+use display_error_chain::ErrorChainExt as _;
+let formatted = TopLevel.into_chain().to_string();
+assert_eq!(
+    formatted,
+    "\
+top level
+Caused by:
+  -> mid level
+  -> low level"
+);
 ```
+
+<!-- cargo-rdme end -->
 
 License: Apache-2.0/MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@
 
 use std::{error::Error, fmt};
 
+mod result_ext;
+pub use result_ext::ResultExt;
+
 /// Provides an [fmt::Display] implementation for an error as a chain.
 ///
 /// ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,30 @@
 //!   -> mid level
 //!   -> low level"
 //! );
+//!
+//! // Or with `.chain()` helper:
+//! use display_error_chain::ErrorChainExt as _;
+//! let formatted = TopLevel.chain().to_string();
+//! assert_eq!(
+//!     formatted,
+//!     "\
+//!top level
+//!Caused by:
+//!   -> mid level
+//!   -> low level"
+//! );
+//!
+//! // Or even with `.into_chain()` helper to consume the error.
+//! use display_error_chain::ErrorChainExt as _;
+//! let formatted = TopLevel.into_chain().to_string();
+//! assert_eq!(
+//!     formatted,
+//!     "\
+//!top level
+//!Caused by:
+//!   -> mid level
+//!   -> low level"
+//! );
 //! ```
 
 use std::{error::Error, fmt};
@@ -100,8 +124,25 @@ pub use result_ext::ResultExt;
 /// // You can also use a `.chain()` shortcut from the `ErrorChainExt` trait.
 /// let formatted = no_cause.chain().to_string();
 /// assert_eq!("No cause", formatted);
+///
+/// // or `.into_chain()` to make the `DisplayErrorChain` to consume the error.
+/// let formatted = no_cause.into_chain().to_string();
+/// assert_eq!("No cause", formatted);
+///
+/// // `from` or `into` will also work with both owned and referenced errors:
+/// let chain: DisplayErrorChain<_> = CustomError::NoCause.into();
+/// assert_eq!("No cause", chain.to_string());
+///
+/// let chain: DisplayErrorChain<_> = (&CustomError::NoCause).into();
+/// assert_eq!("No cause", chain.to_string());
 /// ```
 pub struct DisplayErrorChain<E>(E);
+
+impl<E: Error> From<E> for DisplayErrorChain<E> {
+    fn from(value: E) -> Self {
+        DisplayErrorChain::new(value)
+    }
+}
 
 impl<E> DisplayErrorChain<E>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,11 @@ where
     pub fn new(error: E) -> Self {
         DisplayErrorChain(error)
     }
+
+    /// Deconstructs the [`DisplayErrorChain`] and returns the wrapped error.
+    pub fn into_inner(self) -> E {
+        self.0
+    }
 }
 
 impl<E> fmt::Display for DisplayErrorChain<E>

--- a/src/result_ext.rs
+++ b/src/result_ext.rs
@@ -1,0 +1,104 @@
+use std::{error::Error, fmt};
+
+use crate::DisplayErrorChain;
+
+/// A helper extension trait to "unwrap" results with an error chain.
+pub trait ResultExt<T, E> {
+    /// Like [`Result::unwrap`][Result::unwrap], but wraps the error in the
+    /// [DisplayErrorChain] and prints out the full chain in case an `Err(_)`
+    /// value is encountered.
+    #[track_caller]
+    fn unwrap_chain(self) -> T;
+
+    /// Like [`Result::expect`][Result::expect], but wraps the error in the
+    /// [DisplayErrorChain] and prints out the full chain in case an `Err(_)`
+    /// value is encountered.
+    #[track_caller]
+    fn expect_chain(self, msg: &str) -> T;
+}
+
+impl<T, E: Error> ResultExt<T, E> for Result<T, E> {
+    #[inline]
+    #[track_caller]
+    fn unwrap_chain(self) -> T {
+        match self {
+            Ok(value) => value,
+            Err(e) => unwrap_failed(
+                "called `Result::unwrap_chain()` on an `Err` value",
+                &DisplayErrorChain::new(&e),
+            ),
+        }
+    }
+    #[inline]
+    #[track_caller]
+    fn expect_chain(self, msg: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(e) => unwrap_failed(msg, &DisplayErrorChain::new(&e)),
+        }
+    }
+}
+
+// This is a separate function to reduce the code size of the methods
+#[inline(never)]
+#[cold]
+#[track_caller]
+fn unwrap_failed(msg: &str, error: &dyn fmt::Display) -> ! {
+    panic!("{}: {}", msg, error)
+}
+
+#[cfg(test)]
+mod test {
+    use super::ResultExt;
+
+    macro_rules! impl_error {
+        ($ty:ty, $display:expr, $source:expr) => {
+            impl ::std::fmt::Display for $ty {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    write!(f, "{}", $display)
+                }
+            }
+
+            impl ::std::error::Error for $ty {
+                fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+                    $source
+                }
+            }
+        };
+    }
+
+    // `TopLevel` is caused by a `MidLevel`.
+    #[derive(Debug)]
+    struct TopLevel;
+    impl_error!(TopLevel, "top level", Some(&MidLevel));
+
+    // `MidLevel` is caused by a `LowLevel`.
+    #[derive(Debug)]
+    struct MidLevel;
+    impl_error!(MidLevel, "mid level", Some(&LowLevel));
+
+    // `LowLevel` is the cause itself.
+    #[derive(Debug)]
+    struct LowLevel;
+    impl_error!(LowLevel, "low level", None);
+
+    #[test]
+    #[should_panic(expected = "\
+    called `Result::unwrap_chain()` on an `Err` value: top level\n\
+Caused by:
+  -> mid level
+  -> low level")]
+    fn test_unwrap() {
+        Err::<(), _>(TopLevel).unwrap_chain();
+    }
+
+    #[test]
+    #[should_panic(expected = "\
+    Some message: top level\n\
+Caused by:
+  -> mid level
+  -> low level")]
+    fn test_expect() {
+        Err::<(), _>(TopLevel).expect_chain("Some message");
+    }
+}


### PR DESCRIPTION
**This is a breaking change** since the signature of the `DisplayErrorChain` is changed. Most of the user code should compile though.

- [x] No lifetime in the signature.
- [x] Can make `DisplayErrorChain` to consume (to own) the error.
- [x] Add `unwrap_chain`/`expect_chain` functions.